### PR TITLE
Legger til aktørId for arbeidsgiver og arbeidstaker

### DIFF
--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
@@ -9,15 +9,22 @@ data class Inntektsmelding(
         /** Arbeidstakers fødselsnummer/dnr  */
         @Pattern(regexp = "[0-9]{11}")
         val arbeidstakerFnr: String,
+        /** Arbeidstakers aktørId */
+        @Pattern(regexp = "[0-9]{13}")
+        val arbeidstakerAktorId: String,
         /** Virksomhetsnummer for den virksomheten arbeidstaker er knyttet til (har arbeidsforhold hos)
          * Denne skal ha verdi hvis arbeidsgivertype er virksomhet */
         @Pattern(regexp = "[0-9]{9}")
         val virksomhetsnummer: String? = null,
         /** Arbeidsgivers fødselsnummer/dnr
-         * Denne skal ha verdi hvis arbeidsgivertype er privat */
+         * Denne skal ha verdi hvis arbeidsgiver er en privatperson */
         @Pattern(regexp = "[0-9]{11}")
         val arbeidsgiverFnr: String? = null,
-        /** Hvaslags type arbeidsgiver det gjelder: Privat eller virksomhet */
+        /** Arbeidsgivers aktørId
+         * Denne skal ha verdi hvis arbeidsgiver er en privatperson */
+        @Pattern(regexp = "[0-9]{13}")
+        val arbeidsgiverAktorId: String,
+        /** Hvaslags type arbeidsgiver det gjelder: Privatperson eller virksomhet */
         val arbeidsgivertype: Arbeidsgivertype,
         /** ArbeidsforholdId skal oppgis når en arbeidstaker har flere arbeidsforhold hos den samme virksomheten slik at det
          * må sendes inn flere inntektsmeldinger for en arbeidstaker Det skal benyttes samme arbeidsforholdId som sendes inn

--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
@@ -6,55 +6,71 @@ import javax.validation.constraints.Pattern
 
 data class Inntektsmelding(
 
+        /** TODO forklare hvor denne id'en kommer fra */
+        val inntektsmeldingId: String,
+
         /** Arbeidstakers fødselsnummer/dnr  */
         @Pattern(regexp = "[0-9]{11}")
         val arbeidstakerFnr: String,
+
         /** Arbeidstakers aktørId */
         @Pattern(regexp = "[0-9]{13}")
         val arbeidstakerAktorId: String,
+
         /** Virksomhetsnummer for den virksomheten arbeidstaker er knyttet til (har arbeidsforhold hos)
          * Denne skal ha verdi hvis arbeidsgivertype er virksomhet */
         @Pattern(regexp = "[0-9]{9}")
         val virksomhetsnummer: String? = null,
+
         /** Arbeidsgivers fødselsnummer/dnr
          * Denne skal ha verdi hvis arbeidsgiver er en privatperson */
         @Pattern(regexp = "[0-9]{11}")
         val arbeidsgiverFnr: String? = null,
+
         /** Arbeidsgivers aktørId
          * Denne skal ha verdi hvis arbeidsgiver er en privatperson */
         @Pattern(regexp = "[0-9]{13}")
         val arbeidsgiverAktorId: String? = null,
+
         /** Er arbeidsgiver en organisasjon (identifisert med virksomhetsnummer), eller en privatperson (identifisert med fnr/aktørId) */
         val arbeidsgivertype: Arbeidsgivertype,
+
         /** ArbeidsforholdId skal oppgis når en arbeidstaker har flere arbeidsforhold hos den samme virksomheten slik at det
          * må sendes inn flere inntektsmeldinger for en arbeidstaker Det skal benyttes samme arbeidsforholdId som sendes inn
          * til a-ordningen og arbeidstakerregisteret.   */
         val arbeidsforholdId: String? = null,
+
         /** Felt på sykepenger og svangerskapspenger for å angi første fraværsdag ved alle arbeidsforhold. Feltet trengs for
          * å kunne knytte den enkelte inntektsmeldingen til riktig fravær. Dette er det spesielt behov for dersom den
          * sykmeldte har flere fraværsperioder innenfor et så kort tidsrom at det ikke skal beregnes ny arbeidsgiverperiode.
          * Definisjon av første fraværsdag: Første fraværsdag er den første fraværsdagen i det sammenhengende fraværet som
-         * går utover arbeidsgiverperioden. Dersom det er flere fravær i arbeidsgiverperioden, såer det første dagen i det
+         * går utover arbeidsgiverperioden. Dersom det er flere fravær i arbeidsgiverperioden, så er det første dagen i det
          * fraværet som går utover arbeidsgiverperioden som skal angis. Dersom arbeidstakeren først har vært fraværende på
          * grunn av arbeidsuførhet utover arbeidsgiverperioden (det er sendt inntektsmelding for dette fraværet), så vært i
          * arbeid en eller flere dager(men ikke så lenge at det er ny arbeidsgiverperiode), for så å bli sykmeldt igjen,
          * skal det sendes ny inntektsmelding og den første fraværsdagen i det siste fraværet oppgis.
          * Feltet skal være obligatorisk ved fravær. Dersom man angir «Beløpet er satt til 0,- da det ikke er fravær i dette
-         * arbeidsforholdet» under begrunnelseForReduksjonEllerIkkeUtbetalt, skal  det ikke angis dato.
+         * arbeidsforholdet» under begrunnelseForReduksjonEllerIkkeUtbetalt, skal det ikke angis dato.
          */
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         val foersteFravaersdag: LocalDate? = null,
+
         /** Oppgi inntekt som samsvarer med folketrygdloven § 8-28. Oppgis som månedsbeløp. Beløp med to desimaler.
          * Det skal alltid opplyses full lønn.  */
         val beregnetInntekt: Float? = null,
+
         /** Inneholder opplysninger om refusjon  */
         val refusjon: Refusjon,
+
         /** Inneholder opplysninger om endring i krav om refusjon i fraværsperioden.  */
         val endringIRefusjoner: List<EndringIRefusjon>,
+
         /** Inneholder opplysninger om opphør av naturalytelse.  */
         val opphoerAvNaturalytelser: List<OpphoerAvNaturalytelse>,
+
         /** Inneholder opplysninger om gjenopptakelse av naturalytelse  */
         val gjenopptakelseNaturalytelser: List<GjenopptakelseNaturalytelse>,
+
         /** Om inntektsmeldingen har kjente mangler eller anses som å være gyldig */
         val status: Status
 

--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
@@ -23,7 +23,7 @@ data class Inntektsmelding(
         /** Arbeidsgivers aktørId
          * Denne skal ha verdi hvis arbeidsgiver er en privatperson */
         @Pattern(regexp = "[0-9]{13}")
-        val arbeidsgiverAktorId: String,
+        val arbeidsgiverAktorId: String? = null,
         /** Er arbeidsgiver en organisasjon (identifisert med virksomhetsnummer), eller en privatperson (identifisert med fnr/aktørId) */
         val arbeidsgivertype: Arbeidsgivertype,
         /** ArbeidsforholdId skal oppgis når en arbeidstaker har flere arbeidsforhold hos den samme virksomheten slik at det

--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
@@ -24,7 +24,7 @@ data class Inntektsmelding(
          * Denne skal ha verdi hvis arbeidsgiver er en privatperson */
         @Pattern(regexp = "[0-9]{13}")
         val arbeidsgiverAktorId: String,
-        /** Hvaslags type arbeidsgiver det gjelder: Privatperson eller virksomhet */
+        /** Er arbeidsgiver en organisasjon (identifisert med virksomhetsnummer), eller en privatperson (identifisert med fnr/aktørId) */
         val arbeidsgivertype: Arbeidsgivertype,
         /** ArbeidsforholdId skal oppgis når en arbeidstaker har flere arbeidsforhold hos den samme virksomheten slik at det
          * må sendes inn flere inntektsmeldinger for en arbeidstaker Det skal benyttes samme arbeidsforholdId som sendes inn

--- a/src/test/kotlin/no/nav/inntektsmelding/kontrakt/serde/JacksonJsonConfigTest.kt
+++ b/src/test/kotlin/no/nav/inntektsmelding/kontrakt/serde/JacksonJsonConfigTest.kt
@@ -16,6 +16,7 @@ internal class JacksonJsonConfigTest {
     @Test
     fun skal_deserialisere_dato() {
         val inntektsmelding = Inntektsmelding(
+                inntektsmeldingId = "ENLANGIDENTIFIKATOR",
                 foersteFravaersdag = LocalDate.of(2019, 1, 1),
                 arbeidstakerFnr = "00000000000",
                 arbeidstakerAktorId = "00000000000",
@@ -31,6 +32,5 @@ internal class JacksonJsonConfigTest {
             foersteFravaersdag":"2019-01-01"
         """.trimIndent()))
     }
-
 
 }

--- a/src/test/kotlin/no/nav/inntektsmelding/kontrakt/serde/JacksonJsonConfigTest.kt
+++ b/src/test/kotlin/no/nav/inntektsmelding/kontrakt/serde/JacksonJsonConfigTest.kt
@@ -18,6 +18,7 @@ internal class JacksonJsonConfigTest {
         val inntektsmelding = Inntektsmelding(
                 foersteFravaersdag = LocalDate.of(2019, 1, 1),
                 arbeidstakerFnr = "00000000000",
+                arbeidstakerAktorId = "00000000000",
                 refusjon = Refusjon(),
                 endringIRefusjoner = emptyList(),
                 opphoerAvNaturalytelser = emptyList(),


### PR DESCRIPTION
Vi foretrekker å bruke aktørId internt i løsningen, og heller oversette fra/til fnr for visning i brukergrensesnittet. Dette begrenser antall oppslag mot aktørregisteret, og gjør det også noe vanskeligere å identifisere personen for uvedkommende.

Vurderte å lage et Person-objekt for feltene fnr og aktørId, men valgte en litt naiv tilnærming - åpen for å gjøre om på det.