### PR TITLE
Lagt til flagg matcherSpleis

### DIFF
--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
@@ -25,7 +25,8 @@ data class Inntektsmelding @JsonCreator constructor(
     @JsonProperty("vedtaksperiodeId")
     val vedtaksperiodeId: UUID? = null,
 
-    /** Boolean - True dersom IM er svar på en forespørsel, eller om en selvbestemt / arbeidsgiverInitiert IM matcher en forespørsel eller en potensiell forespørsel fra Spleis.
+    /** Boolean - True dersom IM er svar på en forespørsel,
+     *  eller om en arbeidsgiverInitiert IM matcher en forespørsel eller potensiell forespørsel fra Spleis.
      *  Hvis satt til false kan Spleis ignorere denne IM, den vil da behandles i gosys / infotrygd
      * */
     @JsonProperty("matcherSpleis")

--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Inntektsmelding.kt
@@ -25,6 +25,12 @@ data class Inntektsmelding @JsonCreator constructor(
     @JsonProperty("vedtaksperiodeId")
     val vedtaksperiodeId: UUID? = null,
 
+    /** Boolean - True dersom IM er svar på en forespørsel, eller om en selvbestemt / arbeidsgiverInitiert IM matcher en forespørsel eller en potensiell forespørsel fra Spleis.
+     *  Hvis satt til false kan Spleis ignorere denne IM, den vil da behandles i gosys / infotrygd
+     * */
+    @JsonProperty("matcherSpleis")
+    val matcherSpleis: Boolean = true,
+
     /** Arbeidstakers fødselsnummer/dnr  */
     @Pattern(regexp = "[0-9]{11}")
     @JsonProperty("arbeidstakerFnr")


### PR DESCRIPTION
Denne property forteller Spleis om en IM ikke matcher noe hos dem, altså en arbeidsgiverInitiert inntektsmelding som ikke treffer noe. 
Spleis vil da ignorere disse, og vi oppretter gosys-oppgave umiddelbart. 