### PR TITLE
Fjerner @JsonCreator fra Refusjon og EndringIRefusjon for å fikse konflikt med jackson-module-kotlin

### DIFF
--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/EndringIRefusjon.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/EndringIRefusjon.kt
@@ -1,13 +1,12 @@
 package no.nav.inntektsmeldingkontrakt
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import java.math.BigDecimal
 import java.time.LocalDate
 
-data class EndringIRefusjon @JsonCreator constructor(
+data class EndringIRefusjon(
 
     /** Dersom arbeidsgiver krever refusjon og refusjonsbeløpet er lavere enn den beregnede månedsinntekten, skal
      * arbeidsgiver opplyse beløpet per måned samt en fra og med dato refusjonsbeløpet gjelder fra. Dette og feltet

--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Refusjon.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Refusjon.kt
@@ -1,13 +1,12 @@
 package no.nav.inntektsmeldingkontrakt
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import java.math.BigDecimal
 import java.time.LocalDate
 
-data class Refusjon @JsonCreator constructor(
+data class Refusjon(
 
         /** Dersom arbeidsgiver krever refusjon angis refusjonsbeløpet. Beløpet oppgis som månedsbeløp. Refusjonsbeløpet må
          * være likt eller mindre enn den beregnede inntekten per måned. Refusjonsbeløpet skal ikke reduseres i henhold til


### PR DESCRIPTION
## Problem

Jackson 2.18+ er strengere med konflikter mellom `@JsonCreator`-annotasjoner. `jackson-module-kotlin` registrerer nå automatisk no-arg constructor som `@JsonCreator` for Kotlin data classes der alle parametere har default-verdier. Dette kolliderer med den eksplisitte `@JsonCreator` på primary constructor i `Refusjon` og `EndringIRefusjon`.

Feilen som oppstår:
```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Conflicting property-based creators: 
already had explicit creator [constructor for `no.nav.inntektsmeldingkontrakt.Refusjon` (0 args)], 
encountered another: [constructor for `no.nav.inntektsmeldingkontrakt.Refusjon` (2 args)]
```

## Fix

Fjerner `@JsonCreator` fra `Refusjon` og `EndringIRefusjon`. `jackson-module-kotlin` håndterer Kotlin data classes automatisk og annotasjonen er ikke lenger nødvendig.