### PR TITLE
Oppdater til Jackson versjon 2.21.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,16 +18,17 @@ plugins {
     id("maven-publish")
 }
 
-val jacksonVersion = "2.16.1"
+val jacksonVersion = "2.21.2"
 
 dependencies {
     implementation(kotlin("stdlib"))
     implementation("com.migesok", "jaxb-java-time-adapters", javaTimeAdapterVersion)
-    implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
-    implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
-    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
+    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+    implementation("com.fasterxml.jackson.core:jackson-core")
+    implementation("com.fasterxml.jackson.core:jackson-annotations")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("javax.validation:validation-api:2.0.1.Final")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")

--- a/src/main/kotlin/no/nav/inntektsmelding/kontrakt/serde/JacksonJsonConfig.kt
+++ b/src/main/kotlin/no/nav/inntektsmelding/kontrakt/serde/JacksonJsonConfig.kt
@@ -18,7 +18,7 @@ class JacksonJsonConfig {
             objectMapper.registerModule(JavaTimeModule())
             objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
             return objectMapper
         }
     }

--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/AvsenderSystem.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/AvsenderSystem.kt
@@ -1,9 +1,8 @@
 package no.nav.inntektsmeldingkontrakt
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class AvsenderSystem @JsonCreator constructor(
+data class AvsenderSystem(
     @JsonProperty("navn")
     val navn: String? = null,
     @JsonProperty("versjon")

--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/EndringIRefusjon.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/EndringIRefusjon.kt
@@ -1,13 +1,12 @@
 package no.nav.inntektsmeldingkontrakt
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import java.math.BigDecimal
 import java.time.LocalDate
 
-data class EndringIRefusjon @JsonCreator constructor(
+data class EndringIRefusjon(
 
     /** Dersom arbeidsgiver krever refusjon og refusjonsbeløpet er lavere enn den beregnede månedsinntekten, skal
      * arbeidsgiver opplyse beløpet per måned samt en fra og med dato refusjonsbeløpet gjelder fra. Dette og feltet

--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/GjenopptakelseNaturalytelse.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/GjenopptakelseNaturalytelse.kt
@@ -1,13 +1,12 @@
 package no.nav.inntektsmeldingkontrakt
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import java.math.BigDecimal
 import java.time.LocalDate
 
-data class GjenopptakelseNaturalytelse @JsonCreator constructor(
+data class GjenopptakelseNaturalytelse(
 
         /** Hvis arbeidstaker igjen skulle motta naturalytelsen så skal det oppgis hvilken naturalytelse dette gjelder.  */
         @JsonProperty("naturalYtelse")

--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/OpphoerAvNaturalytelse.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/OpphoerAvNaturalytelse.kt
@@ -1,13 +1,12 @@
 package no.nav.inntektsmeldingkontrakt
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import java.math.BigDecimal
 import java.time.LocalDate
 
-data class OpphoerAvNaturalytelse @JsonCreator constructor(
+data class OpphoerAvNaturalytelse(
 
         /** Type Naturalytelse som faller bort i stønadsperioden og som ikke blir erstattet skal meldes inn.  */
         @JsonProperty("naturalytelse")

--- a/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Refusjon.kt
+++ b/src/main/kotlin/no/nav/inntektsmeldingkontrakt/Refusjon.kt
@@ -1,13 +1,12 @@
 package no.nav.inntektsmeldingkontrakt
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import java.math.BigDecimal
 import java.time.LocalDate
 
-data class Refusjon @JsonCreator constructor(
+data class Refusjon(
 
         /** Dersom arbeidsgiver krever refusjon angis refusjonsbeløpet. Beløpet oppgis som månedsbeløp. Refusjonsbeløpet må
          * være likt eller mindre enn den beregnede inntekten per måned. Refusjonsbeløpet skal ikke reduseres i henhold til


### PR DESCRIPTION
- Bruker jackson BOM (Bill Of Materials) og [ungår bug der jackson-annotations ikke har 2.21.2](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations/versions)
- setSerializationInclusion deprecated i ny Jackson
- Fjerner @JsonCreator fra dataklasser der alle parametre har defaultverdier fordi dette skaper konflikt i ny Jackson (har med teknisk hvordan Kotlin konverterer data class til JVM)